### PR TITLE
Fix for predictive text

### DIFF
--- a/sbapp/ui/messages.py
+++ b/sbapp/ui/messages.py
@@ -711,6 +711,7 @@ MDScreen:
             MDTextField:
                 id: message_text
                 keyboard_suggestions: True
+                input_type: "text"
                 multiline: True
                 hint_text: "Write message"
                 mode: "rectangle"


### PR DESCRIPTION
Kivy's default for input boxes changed from "text" to "null" in Kivy 2.1.0. Not specifying it disallowed typing using predictive text keyboards such as Gboard or Swiftkey swiping, which was irritating, when you are typing text messages.

From [Kivy documentation](
https://kivy.org/doc/stable/api-kivy.uix.behaviors.html#kivy.uix.behaviors.FocusBehavior):

input_type

```
The kind of input keyboard to request.

New in version 1.8.0.
Changed in version 2.1.0: Changed default value from text to null. Added null to options.

Warning
As the default value has been changed, you may need to adjust input_type in your code.
```
