### PR TITLE
Fix sideband not detecting RAK4631

### DIFF
--- a/sbapp/services/sidebandservice.py
+++ b/sbapp/services/sidebandservice.py
@@ -58,6 +58,7 @@ class SidebandService():
         0x1a86: [0x5523, 0x7523, 0x55D4], # Qinheng
         0x0483: [0x5740], # ST CDC
         0x2E8A: [0x0005, 0x000A], # Raspberry Pi Pico
+        0x239A: [0x8029], # Adafruit (RAK4631)
     }
     
     def android_notification(self, title="", content="", ticker="", group=None, context_id=None):


### PR DESCRIPTION
Title really.

When Mark added support for the RAK4631, he forgot to add the correct values to this last USB filter, causing the device to never be detected.
