### PR TITLE
fix formatting of rnode server urls

### DIFF
--- a/sbapp/main.py
+++ b/sbapp/main.py
@@ -3753,11 +3753,11 @@ class SidebandApp(MDApp):
             else:
                 ipstr = ""
                 for ip in ips:
-                    ipstr += "https://"+str(ip)+":4444/"
-                    self.reposository_url = ipstr
+                    ipstr += "[u][ref=link]https://" + str(ip) + ":4444/[/ref][u]\n"
+                self.repository_url = ipstr
 
                 ms = "" if len(ips) == 1 else "es"
-                info += "The repository server is running at the following address"+ms+":\n [u][ref=link]"+ipstr+"[/ref][u]\n"
+                info += "The repository server is running at the following address" + ms +":\n"+ipstr
                 self.repository_screen.ids.repository_info.bind(on_ref_press=self.repository_link_action)
 
             def cb(dt):


### PR DESCRIPTION
The flasher is available on multiple urls, but those were formatted as one (obviously invalid) concatenated link:
![image](https://github.com/user-attachments/assets/16d43aa5-d233-42c1-80d1-48abd1741614)


This PR fixes the formatting

Also, it is untested.

replaces #67 