### PR TITLE
Fix kivy path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ __variant__ = get_variant()
 
 def glob_paths(pattern):
     out_files = []
-    src_path = os.path.join(os.path.dirname(__file__), "kivymd")
+    src_path = os.path.join(os.path.dirname(__file__), "sbapp/kivymd")
 
     for root, dirs, files in os.walk(src_path):
         for file in files:


### PR DESCRIPTION
I was trying to debug a [build of Sideband in nixpkgs](https://github.com/NixOS/nixpkgs/pull/378373) and noticed that .kv files weren't included in the build. I haven't messed with setup.py files in quite a few years, so I might be mistaken, but I believe this patch is needed for them to be included.

I wonder how/why this works currently?