### PR TITLE
Trap and log errors when loading plugins

### DIFF
--- a/sbapp/sideband/core.py
+++ b/sbapp/sideband/core.py
@@ -849,7 +849,11 @@ class SidebandCore():
                             plugin_globals["SidebandTelemetryPlugin"] = SidebandTelemetryPlugin
                             RNS.log("Loading plugin \""+str(file)+"\"", RNS.LOG_NOTICE)
                             plugin_path = os.path.join(plugins_path, file)
-                            exec(open(plugin_path).read(), plugin_globals)
+                            try:
+                                exec(open(plugin_path).read(), plugin_globals)
+                            except Exception as e:
+                                RNS.log("Error loading plugin \""+str(file)+"\": "+str(e), RNS.LOG_ERROR)
+                                continue
                             plugin_class = plugin_globals["plugin_class"]
                             
                             if plugin_class != None:


### PR DESCRIPTION
A single broken plugin fully invalidates loading; moreover, error logs on Android were empty. I've simply wrapped the `exec` call in a `try... except` and logged eventual exceptions.